### PR TITLE
Correct errors in match-syntax.md

### DIFF
--- a/docs/match-syntax.md
+++ b/docs/match-syntax.md
@@ -107,7 +107,7 @@ Match a specific manufacturer and product:
 
 ```
 [
-  ["system_vendor.manufacturer", "matches", "Dell"],
-  ["system_vendor.product_name", "matches", "PowerEdge M620"]
+  ["inventory.system_vendor.manufacturer", "matches", "Dell"],
+  ["inventory.system_vendor.product_name", "matches", "PowerEdge M620"]
 ]
 ```


### PR DESCRIPTION
This corrects a path error in match-syntax.md.

Closes #22